### PR TITLE
Feature/asymmetric trap

### DIFF
--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -101,8 +101,8 @@ class Field(ABC):
         self.B_f = None
 
     @abstractmethod
-    def get_B_max(self, r):
-        """ Return maximal magnetic field for a given radius """
+    def get_B_max(self, r, zmin=None, zmax=None):
+        """ Return maximal magnetic field for a given radius between zmin and zmax"""
         pass
 
     @abstractmethod
@@ -388,7 +388,7 @@ class MultiCoilField(Field):
                                   method='secant', x0=z[idx-1], x1=z[idx+1]).root
             else:
                 max_pos = z[idx]
-                
+
             # evaluate the field at the maximum
             B_max = self.evaluate_B(np.array([[r, max_pos]]))[0]
             print('z max', max_pos, 'B max', B_max)
@@ -497,7 +497,7 @@ class AnalyticRotationSymmetricField(Field):
 
         return B, dB
 
-    def get_B_max(self, r):
+    def get_B_max(self, r, zmin=None, zmax=None):
         # we ignore the r, sorry
         # if largest a_l coefficient is positive we get to infinity at large z
         if self.coef_al[max(self.coef_al.keys())] > 0:

--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -326,10 +326,15 @@ class Field(ABC):
         z = np.linspace(-zmax, zmax, nz)
 
         for r in r_vals:
-            field_line = self.gen_field_line(r, z0, dz, zmax)
+            field_line_pos = self.gen_field_line(r, z0, dz, zmax, positive_branch=True)
+            field_line_neg = self.gen_field_line(r, z0, dz, zmax, positive_branch=False)
 
+            neg = z<0
+            r_ = np.empty_like(z)
+            r_[neg] = field_line_neg(z[neg])
+            r_[~neg] = field_line_pos(z[~neg])
 
-            r_ = field_line(np.abs(z))
+           # r_ = field_line(np.abs(z))
 
             plt.plot(z,r_, c=color)
 

--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -143,7 +143,7 @@ class Field(ABC):
         pos_z = [z0]
         pos_r = [r0]
         while sign*pos_z[-1]<zmax:
-            B = self.evaluat_B(np.array([pos_r[-1], pos_z[-1]]))
+            B = self.evaluate_B(np.array([pos_r[-1], pos_z[-1]]))
             B_mag = np.sqrt(B[0]**2 + B[1]**2)
             dz = sign*B[1]/B_mag*dt
             dr = sign*B[0]/B_mag*dt

--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -135,27 +135,24 @@ class Field(ABC):
         curv[~B0] = 1/B_mag[~B0]**3*(Bz[~B0]*(Br[~B0]*dBrho_rho[~B0] + Bz[~B0]*dBrho_z[~B0]) - Br[~B0]*(Bz[~B0]*dBz_rho[~B0] + Bz[~B0]*dBz_rho[~B0]))
 
         return B_mag, grad, curv
+    
+    def gen_field_line(self, r0, z0, dt, zmax, positive_branch=True):
 
-    def gen_field_line(self, r0, z0, dt, zmax, both_directions=False):
+        sign = 1 if positive_branch else -1
 
         pos_z = [z0]
         pos_r = [r0]
-        while pos_z[-1]<zmax:
-            B = self.evaluate_B(np.array([pos_r[-1], pos_z[-1]]))
+        while sign*pos_z[-1]<zmax:
+            B = self.evaluat_B(np.array([pos_r[-1], pos_z[-1]]))
             B_mag = np.sqrt(B[0]**2 + B[1]**2)
-            dz = B[1]/B_mag*dt
-            dr = B[0]/B_mag*dt
+            dz = sign*B[1]/B_mag*dt
+            dr = sign*B[0]/B_mag*dt
             pos_z.append(pos_z[-1]+dz)
             pos_r.append(pos_r[-1]+dr)
 
-        if both_directions:
-            while pos_z[0]>-zmax:
-                B = self.evaluate_B(np.array([pos_r[0], pos_z[0]]))
-                B_mag = np.sqrt(B[0]**2 + B[1]**2)
-                dz = -B[1]/B_mag*dt
-                dr = -B[0]/B_mag*dt
-                pos_z.insert(0, pos_z[0]+dz)
-                pos_r.insert(0, pos_r[0]+dr)
+        if not positive_branch:
+            pos_z = pos_z[::-1]
+            pos_r = pos_r[::-1]
 
         line = make_interp_spline(pos_z, pos_r, bc_type='clamped')
 

--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -135,7 +135,7 @@ class Field(ABC):
 
         return B_mag, grad, curv
 
-    def gen_field_line(self, r0, z0, dt, zmax, direction_positive_z=False):
+    def gen_field_line(self, r0, z0, dt, zmax, both_directions=False):
 
         pos_z = [z0]
         pos_r = [r0]
@@ -144,11 +144,17 @@ class Field(ABC):
             B_mag = np.sqrt(B[0]**2 + B[1]**2)
             dz = B[1]/B_mag*dt
             dr = B[0]/B_mag*dt
-            if direction_positive_z:
-                pos_z.append(pos_z[-1]+dz)
-            else:
-                pos_z.append(pos_z[-1]-dz)
+            pos_z.append(pos_z[-1]+dz)
             pos_r.append(pos_r[-1]+dr)
+
+        if both_directions:
+            while pos_z[0]>-zmax:
+                B = self.evaluate_B(np.array([pos_r[0], pos_z[0]]))
+                B_mag = np.sqrt(B[0]**2 + B[1]**2)
+                dz = -B[1]/B_mag*dt
+                dr = -B[0]/B_mag*dt
+                pos_z.insert(0, pos_z[0]+dz)
+                pos_r.insert(0, pos_r[0]+dr)
 
         line = make_interp_spline(pos_z, pos_r, bc_type='clamped')
 

--- a/cresana/bfield.py
+++ b/cresana/bfield.py
@@ -135,7 +135,7 @@ class Field(ABC):
 
         return B_mag, grad, curv
 
-    def gen_field_line(self, r0, z0, dt, zmax):
+    def gen_field_line(self, r0, z0, dt, zmax, direction_positive_z=False):
 
         pos_z = [z0]
         pos_r = [r0]
@@ -144,7 +144,10 @@ class Field(ABC):
             B_mag = np.sqrt(B[0]**2 + B[1]**2)
             dz = B[1]/B_mag*dt
             dr = B[0]/B_mag*dt
-            pos_z.append(pos_z[-1]+dz)
+            if direction_positive_z:
+                pos_z.append(pos_z[-1]+dz)
+            else:
+                pos_z.append(pos_z[-1]-dz)
             pos_r.append(pos_r[-1]+dr)
 
         line = make_interp_spline(pos_z, pos_r, bc_type='clamped')

--- a/cresana/trap.py
+++ b/cresana/trap.py
@@ -661,19 +661,29 @@ class ArbitraryTrap(Trap):
                 t_end = dist[-1]/v
 
                 t_out = t_in.copy()
-                t_out %= 4*t_end
-                ind = t_out>2*t_end
-                #t_out[ind] = t_end[ind] - (t_out[ind]-t_end[ind])
-                t_out[ind] = 2*t_end[ind] - t_out[ind]
-                ind = np.abs(t_out)>t_end
-                sign = np.sign(t_out[ind])
-                #t_out[ind] = sign*t_end[ind]-(t_out[ind]-sign*t_end[ind])
-                t_out[ind] = 2*sign*t_end[ind]-t_out[ind]
+                if self._symmetric_trap:
+                    t_out %= 4*t_end
+                    ind = t_out>2*t_end
+                    t_out[ind] = 2*t_end[ind] - t_out[ind]
+                    ind = np.abs(t_out)>t_end
+                    sign = np.sign(t_out[ind])
+                    t_out[ind] = 2*sign*t_end[ind]-t_out[ind]
+                    
+                    negative = t_out<0
+                    res = np.empty_like(t_in)
+                    res[negative] = -interpolation(-t_out[negative]*v[negative])
+                    res[~negative] = interpolation(t_out[~negative]*v[~negative])
+                    
+                else:
+                    t_pos = t_end
+                    t_neg = -dist[0]/v
+                    t_out %= 2*(t_pos+t_neg) # wrap by one full phase
+                    ind = t_out > t_pos
+                    t_out[ind] = 2*t_pos[ind] - t_out[ind] # mirrow time at positive end
+                    ind = t_out < -t_neg
+                    t_out[ind] = -2*t_neg[ind] - t_out[ind] # mirrow time at negative end
 
-                negative = t_out<0
-                res = np.empty_like(t_in)
-                res[negative] = -interpolation(-t_out[negative]*v[negative])
-                res[~negative] = interpolation(t_out[~negative]*v[~negative])
+                    res = interpolation(t_out*v)
 
                 return res
 

--- a/cresana/trap.py
+++ b/cresana/trap.py
@@ -530,10 +530,13 @@ class ArbitraryTrap(Trap):
         return z[ind-1], z[ind]
 
     def min_trapping_angle(self, r):
-        #might need to be checked again for potential walls
-        #after the addition of r(z) due to the field lines
-        B_max = self._b_field.get_B_max(r)
         B_min = self.B_field(r, 0)
+        B_max_left = self._b_field.get_B_max(r, zmax=0.)
+        if self._symmetric_trap:
+            B_max = B_max_left
+        else:
+            B_max_right = self._b_field.get_B_max(r, zmin=0.)
+            B_max = min(B_max_left, B_max_right)
         trapping_angle = np.arcsin(np.sqrt(B_min/B_max))
         return trapping_angle
 
@@ -611,6 +614,8 @@ class ArbitraryTrap(Trap):
         assuming the electron starts at z=0
         """
         r_f = self._b_field.gen_field_line(electron.r, 0., self._field_line_step_size, self._root_guess_max, positive_branch=positive_branch)
+
+        self._check_if_trapped(electron)
 
         root_guess = self.guess_root(r_f, electron.pitch, positive_branch=positive_branch)
 

--- a/cresana_samples/run_coil_simulation.py
+++ b/cresana_samples/run_coil_simulation.py
@@ -27,10 +27,15 @@ coils = [   Coil(r0, z0, 1, I0),
 bfield = MultiCoilField(coils, B_background)
 
 bfield.plot_field_2d(2.5, 10., 100, 200)
+bfield.plot_field_lines(1., 0.0005, 7, z0, dz=0.01, z0=0., nz=1000)
 
 trap = ArbitraryTrap(bfield, root_guess_max=z0, root_guess_steps=1000, integration_steps=100,
                                 field_line_step_size=0.001)
 
+start = time.time()
+Bmax = bfield.get_B_max(1.)
+end = time.time()
+print('Bmax takes [s]', end-start)
 
 print('Bmax', bfield.get_B_max(0.))
 print('Bmin', bfield.get_grad_mag(np.array([[0., 0., 0.]])))
@@ -44,10 +49,6 @@ print('sim takes [s]', end-start)
 
 #query cached frequency
 print('Axial frequency', trap.get_f(electron))
-start = time.time()
-print('zmax', trap.find_zmax(electron))
-end = time.time()
-print('zmax takes [s]', end-start)
 
 tmax = 40.e-6
 N = 2000


### PR DESCRIPTION
Implementation extended to allow for asymmetric trap shapes. The field lines can now be calculated in positive and negative direction starting from z=0, zmax can be evaluated on the positive z branch and negative z branch, ArbritraryTrap has additional keyword argument symmetric_trap that defaults to true to have backward compatibility. Simulation of trajectory is calculated individually for positive and negative z branch both starting at z=0. Solutions are combined and forwarded. 
Tests show that for symmetric fields the same solutions are returned in both symmetric_trap modes. 
Testing asymmetric traps show expected behaviour.
Time in asymmetric mode takes double the time it takes for the symmetric mode.