### PR TITLE
Feature/asymmetric trap fix

### DIFF
--- a/cresana/trap.py
+++ b/cresana/trap.py
@@ -636,11 +636,12 @@ class ArbitraryTrap(Trap):
             left, r_f_left = self._find_zmax_and_rf(electron, positive_branch=False)
 
             def r_f(z):
+                z = np.atleast_1d(z)
                 r = np.empty_like(z)
                 neg = z<0
                 r[neg] = r_f_left(z[neg])
                 r[~neg] = r_f_right(z[~neg])
-                return r
+                return np.squeeze(r)
 
         if right==0:
 


### PR DESCRIPTION
In case of asymetric trap only a scalar is used as argument of r_f(z) while the function assumed an array. 
Fixed by making argument atleast 1d and squeeze at the end to get it back to scalar if a single value.